### PR TITLE
Don't error out on warnings

### DIFF
--- a/quazip/meson.build
+++ b/quazip/meson.build
@@ -36,7 +36,7 @@ quazip_lib = library(
   quazip_pp,
   dependencies: [qt5_dep, zlib_dep],
   cpp_args: quazip_args,
-  override_options: ['cpp_std=c++11']
+  override_options: ['cpp_std=c++11', 'werror=false']
 )
 
 quazip_incdir = include_directories('.')


### PR DESCRIPTION
This release of Quazip triggers a warning when `warning_level` is set to 1 or higher.

See also: stachenov/quazip#53

(BTW, is this the right way to update a wrap zip? Apologies in advance if I got it wrong. I didn't see that in the manual.)